### PR TITLE
Remove todo!() from encode_primitive_dyn and handle unsupported column types

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -126,7 +126,7 @@ impl CollectionAddr {
         let re = regex::Regex::new(r#"^(?<name>[A-Za-z0-9._-]+)(\((?<key>[^)]+)\))?$"#).unwrap();
         let c = re.captures(collection_path_element)?;
 
-        let name = c.name("name").unwrap().as_str().to_string();
+        let name = c.name("name")?.as_str().to_string();
         let key = c.name("key").map(|m| m.as_str().to_string());
 
         Some(Self { name, key })


### PR DESCRIPTION
Hello, 

This PR removes the `todo!()` panic calls from the `encode_primitive_dyn` function and modifies it to return a Result, which holds an error of type `UnsupportedColumnType`. 

Additionally, the function now returns 0 for integers and 0.0 for floating-point types as default values.
The picture shows that PowerBI fails to read primitive data, such as int16, from null values.
![image](https://github.com/user-attachments/assets/df3312c2-6ae3-48db-a6cf-b32387ac65ff)
