### PR TITLE
solves a few issues with the current approach of converting to datetime.

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -605,8 +605,8 @@ mod tests {
 
     #[test]
     fn test_encode_timestamp() {
-        let expected = vec!["2020-01-01T12:00:00.000Z", "2020-01-01T12:01:00.000Z"];
-        let expected_no_tz = vec![
+        let expected = ["2020-01-01T12:00:00.000Z", "2020-01-01T12:01:00.000Z"];
+        let expected_no_tz = [
             "2020-01-01T12:00:00.000+00:00",
             "2020-01-01T12:01:00.000+00:00",
         ];
@@ -620,9 +620,9 @@ mod tests {
             .with_timezone(Arc::from("UTC")),
         ) as Arc<dyn Array>;
 
-        for i in 0..expected.len() {
+        for (i, e) in expected.iter().enumerate() {
             let result = encode_primitive_dyn(&ts_milli, i).unwrap();
-            assert_eq!(result, BytesText::new(expected[i]));
+            assert_eq!(result, BytesText::new(e));
         }
 
         let ts_micro = Arc::new(
@@ -635,9 +635,9 @@ mod tests {
             .with_timezone(Arc::from("UTC")),
         ) as Arc<dyn Array>;
 
-        for i in 0..expected.len() {
+        for (i, e) in expected.iter().enumerate() {
             let result = encode_primitive_dyn(&ts_micro, i).unwrap();
-            assert_eq!(result, BytesText::new(expected[i]));
+            assert_eq!(result, BytesText::new(e));
         }
 
         let ts_second = Arc::new(
@@ -650,9 +650,9 @@ mod tests {
             .with_timezone(Arc::from("UTC")),
         ) as Arc<dyn Array>;
 
-        for i in 0..expected.len() {
+        for (i, e) in expected.iter().enumerate() {
             let result = encode_primitive_dyn(&ts_second, i).unwrap();
-            assert_eq!(result, BytesText::new(expected[i]));
+            assert_eq!(result, BytesText::new(e));
         }
 
         // with no timezone
@@ -663,9 +663,9 @@ mod tests {
             1_577_880_060_000_000,
         ])) as Arc<dyn Array>;
 
-        for i in 0..expected_no_tz.len() {
+        for (i, e) in expected_no_tz.iter().enumerate() {
             let result = encode_primitive_dyn(&ts_micro_no_tz, i).unwrap();
-            assert_eq!(result, BytesText::new(expected_no_tz[i]));
+            assert_eq!(result, BytesText::new(e));
         }
     }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -190,7 +190,8 @@ pub fn to_edm_type(dt: &DataType) -> std::result::Result<&'static str, Unsupport
         DataType::Float16 => Ok("Edm.Single"),
         DataType::Float32 => Ok("Edm.Single"),
         DataType::Float64 => Ok("Edm.Double"),
-        DataType::Timestamp(_, _) => Ok("Edm.DateTime"),
+        DataType::Timestamp(_, None) => Ok("Edm.DateTime"),
+        DataType::Timestamp(_, Some(_)) => Ok("Edm.DateTimeOffset"),
         DataType::Date32 => Ok("Edm.DateTime"),
         DataType::Date64 => Ok("Edm.DateTime"),
         DataType::Null

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -56,8 +56,8 @@ async fn test_metadata() {
             <Key><PropertyRef Name="offset"/></Key>
             <Property Name="offset" Type="Edm.Int64" Nullable="false"/>
             <Property Name="op" Type="Edm.Int32" Nullable="false"/>
-            <Property Name="system_time" Type="Edm.DateTime" Nullable="false"/>
-            <Property Name="reported_date" Type="Edm.DateTime" Nullable="false"/>
+            <Property Name="system_time" Type="Edm.DateTimeOffset" Nullable="false"/>
+            <Property Name="reported_date" Type="Edm.DateTimeOffset" Nullable="false"/>
             <Property Name="province" Type="Edm.String" Nullable="false"/>
             <Property Name="total_daily" Type="Edm.Int64" Nullable="false"/>
             </EntityType>
@@ -65,8 +65,8 @@ async fn test_metadata() {
             <Key><PropertyRef Name="offset"/></Key>
             <Property Name="offset" Type="Edm.Int64" Nullable="true"/>
             <Property Name="op" Type="Edm.Int32" Nullable="true"/>
-            <Property Name="system_time" Type="Edm.DateTime" Nullable="true"/>
-            <Property Name="event_time" Type="Edm.DateTime" Nullable="true"/>
+            <Property Name="system_time" Type="Edm.DateTimeOffset" Nullable="true"/>
+            <Property Name="event_time" Type="Edm.DateTimeOffset" Nullable="true"/>
             <Property Name="from_symbol" Type="Edm.String" Nullable="true"/>
             <Property Name="to_symbol" Type="Edm.String" Nullable="true"/>
             <Property Name="open" Type="Edm.Double" Nullable="true"/>


### PR DESCRIPTION

This PR solves a few problems with the current approach of converting to datetime.
- Correct conversion for timestamp to datetime, and handle all timeunits
- Consider timezone when doing conversion and use [DateTimeOffset](https://www.odata.org/documentation/odata-version-2-0/overview/) if timezone exists.